### PR TITLE
Add TECS-L: Dense-to-MoE Expert Splitting Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Thanks!
 
 | **Paper Title** | **Year** | **Conference/Journal** | **Remark** |
 | --------------- | :----: | :----: | :----: |
+| [TECS-L (Golden MoE): Dense-to-MoE Expert Splitting Framework](https://github.com/need-singularity/TECS-L)| 2026 | GitHub | Mistral-7B |
 | [Fine-Grained Model Merging via Modular Expert Recombination](https://arxiv.org/pdf/2602.06552)| 2026 | Arxiv |
 | [MIN-Merging: Merge the Important Neurons for Model Merging](https://arxiv.org/pdf/2510.17890) | 2025 | Arxiv |
 | [SE-Merging: A Self-Enhanced Approach for Dynamic Model Merging](https://arxiv.org/pdf/2506.18135) | 2025 | Arxiv |


### PR DESCRIPTION
## Summary

- Adds **TECS-L (Golden MoE)** to the **Routing-based Merging Methods (Dynamic Merging)** section
- TECS-L is a framework for converting dense models to Mixture-of-Experts via expert weight splitting with mathematically optimal activation ratios (golden zone inhibition: I ∈ [0.213, 0.500], optimal at 1/e ≈ 0.368)
- Related to model merging as the inverse operation — splitting one dense model into specialized experts with Boltzmann routing
- GitHub: https://github.com/need-singularity/TECS-L
- Evaluated on Mistral-7B

## Test plan

- [x] Entry follows existing table format (Paper Title, Year, Conference/Journal, Remark)
- [x] Placed in Routing-based Merging Methods section alongside related work (e.g., Sparse Upcycling, Self-MoE, SMILE)
- [x] Link is valid and points to public repository