### PR TITLE
Add CRDT merge paper to Benchmark/Evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Thanks!
 | **Paper Title** | **Year** | **Conference/Journal** | **Remark** |
 | --------------- | :----: | :----: | :----: |
 | [crdt-merge](https://github.com/mgillr/crdt-merge)| 2026 | Github | CRDT-based distributed model merging with formal convergence guarantees. 25 strategies (SLERP, TIES, DARE, Fisher, evolutionary). Two-layer OR-Set architecture enabling conflict-free multi-node merge.
+| [Conflict-Free Replicated Data Types for Neural Network Model Merging: A Two-Layer Architecture Enabling CRDT-Compliant Model Merging Across 26 Strategies](https://ssrn.com/abstract=6545518)| 2026 | SSRN | [crdt-merge](https://github.com/mgillr/crdt-merge) |
 | [An Empirical Survey of Model Merging Algorithms for Social Bias Mitigation](https://arxiv.org/pdf/2512.02689)| 2025 | Arxiv | LLAMA-2-7B, LLAMA-3-8B, LLAMA-3.1-8B, QWEN2-7B
 | [A Systematic Study of Model Merging Techniques in Large Language Models](https://arxiv.org/pdf/2511.21437)| 2025 | Arxiv | Llama-3.2-3B-Instruct, Llama-3.1-8B-Instruct, Qwen3-4B, Qwen3-8B
 | [FusionBench: A Comprehensive Benchmark of Deep Model Fusion](https://arxiv.org/pdf/2406.03280)| 2025 | JMLR | Mistral-7B-v0.1, MetaMath-Mistral-7B, dolphin-2.1-mistral-7b, speechless-code-mistral-7b-v1.0


### PR DESCRIPTION
Adds the companion paper for crdt-merge to the Benchmark/Evaluation section:

- **Paper:** Conflict-Free Replicated Data Types for Neural Network Model Merging: A Two-Layer Architecture Enabling CRDT-Compliant Model Merging Across 26 Strategies
- **Link:** https://ssrn.com/abstract=6545518
- **Year:** 2026
- **Venue:** SSRN

The crdt-merge tool is already listed in this section. This adds the formal paper describing its two-layer OR-Set architecture and CRDT-compliant merging framework.