### PR TITLE
Update CRDT model merging paper link (row 151): SSRN → arXiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Thanks!
 | --------------- | :----: | :----: | :----: |
 | [merge-and-rebase](https://github.com/apanariello4/merge-and-rebase) | 2026 | Github | Codebase for model merging, task-vector transport, and configurable fine-tuning across vision and text models. It is built for fast iteration on checkpoint merging, rebasing, and evaluation workflows. Supports both Vison and Language merging.|
 | [crdt-merge](https://github.com/mgillr/crdt-merge)| 2026 | Github | CRDT-based distributed model merging with formal convergence guarantees. 25 strategies (SLERP, TIES, DARE, Fisher, evolutionary). Two-layer OR-Set architecture enabling conflict-free multi-node merge.
-| [Conflict-Free Replicated Data Types for Neural Network Model Merging: A Two-Layer Architecture Enabling CRDT-Compliant Model Merging Across 26 Strategies](https://ssrn.com/abstract=6545518)| 2026 | SSRN | [crdt-merge](https://github.com/mgillr/crdt-merge) |
+| [Conflict-Free Replicated Data Types for Neural Network Model Merging: A Two-Layer Architecture Enabling CRDT-Compliant Model Merging Across 26 Strategies](https://arxiv.org/abs/2605.19373)| 2026 | arXiv | [crdt-merge](https://github.com/mgillr/crdt-merge) |
 | [An Empirical Survey of Model Merging Algorithms for Social Bias Mitigation](https://arxiv.org/pdf/2512.02689)| 2025 | Arxiv | LLAMA-2-7B, LLAMA-3-8B, LLAMA-3.1-8B, QWEN2-7B
 | [A Systematic Study of Model Merging Techniques in Large Language Models](https://arxiv.org/pdf/2511.21437)| 2025 | Arxiv | Llama-3.2-3B-Instruct, Llama-3.1-8B-Instruct, Qwen3-4B, Qwen3-8B
 | [FusionBench: A Comprehensive Benchmark of Deep Model Fusion](https://arxiv.org/pdf/2406.03280)| 2025 | JMLR | Mistral-7B-v0.1, MetaMath-Mistral-7B, dolphin-2.1-mistral-7b, speechless-code-mistral-7b-v1.0


### PR DESCRIPTION
The paper **"Conflict-Free Replicated Data Types for Neural Network Model Merging: A Two-Layer Architecture Enabling CRDT-Compliant Model Merging Across 26 Strategies"** (row 151 in the table) is now available on arXiv.

This PR updates the entry to point at the permanent arXiv version and updates the venue column to match:

- Link: `https://ssrn.com/abstract=6545518` → `https://arxiv.org/abs/2605.19373`
- Venue: `SSRN` → `arXiv`

arXiv:2605.19373 (submitted 2026-05-16). The `crdt-merge` code link is unchanged. Thanks for maintaining this list!
